### PR TITLE
Add functionality to upload attachments on the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 The `confluence_cli` command is used for interacting with Confluence's API via the command line. Here's a breakdown of the command for creating a new page in Confluence:
 
+### 1. Create Page
 ```shell
 confluence_cli create page \
 --space-id {space id} \
@@ -10,13 +11,22 @@ confluence_cli create page \
 --body-value-from-file {file path to file}
 ```
 
+### 2. Upload Attachment
+```shell
+confluence_cli create attachment \
+--page-id {page id} \
+--file {file path}
+```
+
 # Command Components
 
 - `confluence_cli`: The name of the CLI tool designed for Confluence operations.
 
+## Create Page Command
+
 - `create page`: The action to be performed. `create` indicates creation of a new entity, and `page` specifies that the entity is a page within Confluence.
 
-## Options
+### Options for Create Page
 
 ### `--space-id {space id}`:
 - **Description:** Specifies the ID of the space where the new page will be created.
@@ -38,6 +48,25 @@ confluence_cli create page \
 - **Description:** Specifies the file path that contains the content for the page body.
 - **Usage:** Replace `{file path to file}` with the actual path to the content file.
 
+## Upload Attachment Command
+
+- `create attachment`: The action to upload a file as an attachment to an existing Confluence page.
+
+### Options for Upload Attachment
+
+#### `--page-id {page id}`:
+- **Description:** The Content ID (Page ID) of the Confluence page where the file will be uploaded as attachment.
+- **Usage:** Replace `{page id}` with the actual page ID.
+- **How to find Page ID:**
+  - From URL: `https://opswat.atlassian.net/wiki/spaces/SPACE/pages/4114580782/Page+Title`
+  - Page ID is: `4114580782`
+  - Or use Confluence UI: Page → "..." → "Page Information" → Copy "Page ID"
+
+#### `--file {file path}`:
+- **Description:** Path to the file to upload as attachment.
+- **Usage:** Replace `{file path}` with the actual path to the file.
+- **Supported:** All file types supported by Confluence (txt, pdf, images, etc.)
+
 ## Environment Variables.
 
 In order to connect Your Confluence. You must configure the environments such as:   
@@ -52,13 +81,34 @@ In order to connect Your Confluence. You must configure the environments such as
 - **Description:** The Token is used to access Confluence API such as: `XXXXXXXXXXXXXX`
 - **Refer to:** https://nimtechnology.com/2024/01/05/confluence-integrate-with-confluence-by-api/
 
-# How build Binary file.
+## How build Binary file.
 
-On windows
+### On windows
 ```shell
 go build -o confluence_cli.exe
-
-.\confluence_cli.exe create page --space-id 98432 --parent-page-id 589825 --title ahihi --body-value-from-file result.txt
 ```
 
+### On Linux/Mac:
+```shell
+go build -o confluence_cli
+```
 
+## Usage Examples
+
+### Create a Page:
+```shell
+.\confluence_cli.exe create page --space-id 98432 --parent-page-id 589825 --title ahihi --body-value-from-file result.txt
+./confluence_cli create page --space-id 98432 --parent-page-id 589825 --title "Test Page" --body-value "This is the page content"
+```
+
+### Upload Attachment:
+```shell
+./confluence_cli create attachment --page-id 589825 --file /path/to/file
+```
+
+## API Reference
+
+This tool uses the following Confluence REST APIs:
+- **Create Page:** `POST /wiki/api/v2/pages`
+- **Upload Attachment:** `POST /wiki/rest/api/content/{pageId}/child/attachment`
+- **Get Pages by Title:** `GET /wiki/api/v2/pages?title={title}`

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ confluence_cli create attachment \
 - **Description:** The Content ID (Page ID) of the Confluence page where the file will be uploaded as attachment.
 - **Usage:** Replace `{page id}` with the actual page ID.
 - **How to find Page ID:**
-  - From URL: `https://opswat.atlassian.net/wiki/spaces/SPACE/pages/4114580782/Page+Title`
-  - Page ID is: `4114580782`
+  - From URL: `https://<CONFLUENCE_URL>/wiki/spaces/SPACE/pages/123/Page+Title`
+  - Page ID is: `123`
   - Or use Confluence UI: Page → "..." → "Page Information" → Copy "Page ID"
 
 #### `--file {file path}`:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ In order to connect Your Confluence. You must configure the environments such as
 
 ## How build Binary file.
 
-### On windows
+### On Windows
 ```shell
 go build -o confluence_cli.exe
 ```
@@ -97,16 +97,21 @@ go build -o confluence_cli
 
 ### Create a Page:
 ```shell
+### On Windows
 .\confluence_cli.exe create page --space-id 98432 --parent-page-id 589825 --title ahihi --body-value-from-file result.txt
-./confluence_cli create page --space-id 98432 --parent-page-id 589825 --title "Test Page" --body-value "This is the page content"
+### On Linux/Mac
+./confluence_cli create page --space-id 98432 --parent-page-id 589825 --title "Test Page" --body-value-from-file result.txt
 ```
 
 ### Upload Attachment:
 ```shell
+### On Windows
+.\confluence_cli.exe create attachment --page-id 589825 --file /path/to/file
+### On Linux/Mac
 ./confluence_cli create attachment --page-id 589825 --file /path/to/file
 ```
 
-## API Reference
+## API Referenc
 
 This tool uses the following Confluence REST APIs:
 - **Create Page:** `POST /wiki/api/v2/pages`

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ confluence_cli create attachment \
 - **Description:** The Content ID (Page ID) of the Confluence page where the file will be uploaded as attachment.
 - **Usage:** Replace `{page id}` with the actual page ID.
 - **How to find Page ID:**
-  - From URL: `https://<CONFLUENCE_URL>/wiki/spaces/SPACE/pages/123/Page+Title`
-  - Page ID is: `123`
+  - From URL: `https://<CONFLUENCE_URL>/wiki/spaces/SPACE/pages/589825/Page+Title`
+  - Page ID is: `589825`
   - Or use Confluence UI: Page → "..." → "Page Information" → Copy "Page ID"
 
 #### `--file {file path}`:

--- a/confluence_actions/upload_actions.go
+++ b/confluence_actions/upload_actions.go
@@ -1,0 +1,66 @@
+package confluence_actions
+
+import (
+	"confluence_cli/helper/http_request"
+	"confluence_cli/log"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+)
+
+func UploadAttachmentAction(c *cli.Context) error {
+	contentId := c.String("page-id")
+	if contentId == "" {
+		log.Error("Please provide --page-id xxxx")
+		return fmt.Errorf("please provide --page-id xxxx")
+	}
+
+	filePath := c.String("file")
+	if filePath == "" {
+		log.Error("Please provide --file /path/to/file")
+		return fmt.Errorf("please provide --file /path/to/file")
+	}
+
+	// Check if file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		log.Error("File does not exist:", filePath)
+		return fmt.Errorf("file does not exist: %s", filePath)
+	}
+
+	// Get file info for logging
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		log.Error("Error getting file info:", err)
+		return err
+	}
+
+	// Check if file is empty
+	if fileInfo.Size() == 0 {
+		log.Error("File is empty:", filePath)
+		return fmt.Errorf("file is empty: %s", filePath)
+	}
+
+	log.Info("Uploading file:", filepath.Base(filePath), "Size:", fileInfo.Size(), "bytes")
+	log.Info("Content ID:", contentId)
+
+	resp, err := http_request.UploadConfluenceAttachment(contentId, filePath)
+	if err != nil {
+		log.Error("Error when uploading file via Confluence API:", err)
+		return err
+	}
+
+	log.Info("Response status:", resp.Status())
+	log.Info("Response code:", resp.StatusCode())
+
+	if resp.StatusCode() == 200 {
+		log.Info("File uploaded successfully!")
+	} else {
+		log.Error("Upload failed with status:", resp.Status())
+		log.Error("Response body:", string(resp.Body()))
+		return fmt.Errorf("upload failed with status: %s", resp.Status())
+	}
+
+	return nil
+}

--- a/confluence_actions/upload_actions.go
+++ b/confluence_actions/upload_actions.go
@@ -54,7 +54,7 @@ func UploadAttachmentAction(c *cli.Context) error {
 	log.Info("Response status:", resp.Status())
 	log.Info("Response code:", resp.StatusCode())
 
-	if resp.StatusCode() == 200 {
+	if resp.StatusCode() == 200 && resp.StatusCode() < 300 {
 		log.Info("File uploaded successfully!")
 	} else {
 		log.Error("Upload failed with status:", resp.Status())

--- a/confluence_commands/create_commands.go
+++ b/confluence_commands/create_commands.go
@@ -2,6 +2,7 @@ package confluence_commands
 
 import (
 	"confluence_cli/confluence_actions"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -34,6 +35,21 @@ func CreatePageCommand() *cli.Command {
 					&cli.StringFlag{
 						Name:  "body-value",
 						Usage: "The content for the page body",
+					},
+				},
+			},
+			{
+				Name:   "attachment",
+				Usage:  "Upload a file as attachment to a Confluence page",
+				Action: confluence_actions.UploadAttachmentAction,
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "page-id",
+						Usage: "The ID of the page where the file will be uploaded as attachment",
+					},
+					&cli.StringFlag{
+						Name:  "file",
+						Usage: "Path to the file to upload",
 					},
 				},
 			},

--- a/helper/http_request/confluence_httpRequest.go
+++ b/helper/http_request/confluence_httpRequest.go
@@ -4,6 +4,7 @@ import (
 	"confluence_cli/helper"
 	"confluence_cli/log"
 	"confluence_cli/model/req"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -95,6 +96,11 @@ func UploadConfluenceAttachment(pageId, filePath string) (*resty.Response, error
 	if err != nil {
 		log.Error("Error uploading file:", err)
 		return nil, err
+	}
+	// Validate HTTP response status
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		log.Error("HTTP error:", resp.Status(), "Body:", string(resp.Body()))
+		return resp, fmt.Errorf("HTTP error: %s", resp.Status())
 	}
 
 	return resp, nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to upload files as attachments to Confluence pages via a new CLI subcommand.
- **Documentation**
  - Enhanced the README with detailed instructions and examples for the new attachment upload feature, updated usage examples, and added an API Reference section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->